### PR TITLE
Remove apm enabled parameter

### DIFF
--- a/Handler/ApmHandler.php
+++ b/Handler/ApmHandler.php
@@ -42,21 +42,19 @@ class ApmHandler extends AbstractProcessingHandler
      */
     protected function write(array $record): void
     {
-        if (true === $this->agentService->getApmEnabled()) {
-            // Try the default behavior for the Monolog implementation
-            if (
-                false === empty($record[static::CONTEXT_KEY][static::EXCEPTION_KEY])
-                && $record[static::CONTEXT_KEY][static::EXCEPTION_KEY] instanceof \Throwable
-            ) {
-                $this->agentService->error($record[static::CONTEXT_KEY][static::EXCEPTION_KEY], $record[static::CONTEXT_KEY]);
-            } else {
-                /**
-                 * Just a safety net if the record is not well-structured.
-                 * Should never happen unless Monolog wiring is not properly done.
-                 */
-                $ex = new \LogicException(static::MISSING_THROWABLE_ERROR);
-                $this->agentService->error($ex, $record);
-            }
+        // Try the default behavior for the Monolog implementation
+        if (
+            false === empty($record[static::CONTEXT_KEY][static::EXCEPTION_KEY])
+            && $record[static::CONTEXT_KEY][static::EXCEPTION_KEY] instanceof \Throwable
+        ) {
+            $this->agentService->error($record[static::CONTEXT_KEY][static::EXCEPTION_KEY], $record[static::CONTEXT_KEY]);
+        } else {
+            /**
+             * Just a safety net if the record is not well-structured.
+             * Should never happen unless Monolog wiring is not properly done.
+             */
+            $ex = new \LogicException(static::MISSING_THROWABLE_ERROR);
+            $this->agentService->error($ex, $record);
         }
     }
 }

--- a/Tests/Handler/ApmHandlerTest.php
+++ b/Tests/Handler/ApmHandlerTest.php
@@ -1,17 +1,17 @@
 <?php
+
 /**
  * @author      Wizacha DevTeam <dev@wizacha.com>
  * @license     Proprietary
  * @copyright   Copyright (c) Wizacha
  */
+
 declare(strict_types=1);
 
 namespace Wizacha\ElasticApm\Tests\Handler;
 
 use Monolog\Logger;
-use PhilKra\Agent;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Wizacha\ElasticApm\Handler\ApmHandler;
 use Wizacha\ElasticApm\Service\AgentService;
 
@@ -25,12 +25,11 @@ class ApmHandlerTest extends TestCase
     public function testMissingThrowable(): void
     {
         $agentService = $this->getMockBuilder(AgentService::class)->disableOriginalConstructor()->getMock();
-        $agentService->method('getApmEnabled')->will($this->returnValue(true));
         $agentService->expects($this->once())->method('error')->with(
             $this->callback(function (\Exception $exception) {
                 return ApmHandler::MISSING_THROWABLE_ERROR === $exception->getMessage();
-            }
-        ));
+            })
+        );
 
         $apmHandler = new ApmHandler($agentService, Logger::ERROR);
         $apmHandler->handle(['level' => Logger::ERROR, 'extra' => [], 'context' => []]);
@@ -48,30 +47,9 @@ class ApmHandlerTest extends TestCase
         ];
 
         $agentService = $this->getMockBuilder(AgentService::class)->disableOriginalConstructor()->getMock();
-        $agentService->method('getApmEnabled')->will($this->returnValue(true));
         $agentService->expects($this->once())->method('error')->with($exception, $context);
 
         $apmHandler = new ApmHandler($agentService, Logger::ERROR);
         $apmHandler->handle(['level' => Logger::ERROR, 'extra' => [], 'context' => $context]);
-    }
-
-    public function testNoLogWithApmNotEnabled()
-    {
-        $exception = new \LogicException('Oops, something is broken');
-        $context = [
-            ApmHandler::EXCEPTION_KEY => $exception,
-            ApmHandler::CONTEXT_KEY => [],
-        ];
-
-        $agentService = $this->getMockBuilder(AgentService::class)->disableOriginalConstructor()->getMock();
-
-        $agentService->method('getApmEnabled')->will($this->returnValue(false));
-
-        $apmHandler = new ApmHandler($agentService, Logger::ERROR);
-
-        $agentService->expects($this->never())->method('error');
-
-        $apmHandler->handle(['level' => Logger::ERROR, 'extra' => [], 'context' => $context]);
-
     }
 }

--- a/Tests/Service/AgentServiceTest.php
+++ b/Tests/Service/AgentServiceTest.php
@@ -51,7 +51,6 @@ class AgentServiceTest extends TestCase
         ;
 
         $agentService = new AgentService(
-            true,
             $this->logger,
             $this->agentPhilkraService
         );
@@ -65,7 +64,6 @@ class AgentServiceTest extends TestCase
     public function testStartNewTransactionWhileAlreadyStarted(): void
     {
         $agentService = new AgentService(
-            true,
             $this->logger,
             $this->agentPhilkraService
         );
@@ -84,30 +82,11 @@ class AgentServiceTest extends TestCase
     }
 
     /**
-     * @covers  \Wizacha\ElasticApm\Service\AgentService::startTransaction
-     */
-    public function testStartNewTransactionWithFlagFalse(): void
-    {
-        $agentService = new AgentService(
-            false,
-            $this->logger,
-            $this->agentPhilkraService
-        );
-
-        $this->agentPhilkraService->expects($this->never())
-            ->method('startTransaction')
-        ;
-
-        static::assertInstanceOf(AgentService::class, $agentService->startTransaction($this->transactionName));
-    }
-
-    /**
      * @covers  \Wizacha\ElasticApm\Service\AgentService::stopTransaction
      */
     public function testStopExistentTransaction(): void
     {
         $agentService = new AgentService(
-            true,
             $this->logger,
             $this->agentPhilkraService
         );
@@ -134,7 +113,6 @@ class AgentServiceTest extends TestCase
     public function testStopTransactionSendFailure(): void
     {
         $agentService = new AgentService(
-            true,
             $this->logger,
             $this->agentPhilkraService
         );
@@ -156,7 +134,6 @@ class AgentServiceTest extends TestCase
     public function testStopNonExistentTransaction(): void
     {
         $agentService = new AgentService(
-            true,
             $this->logger,
             $this->agentPhilkraService
         );
@@ -181,7 +158,6 @@ class AgentServiceTest extends TestCase
     public function testStartSpanWithExistentTransaction(): void
     {
         $agentService = new AgentService(
-            true,
             $this->logger,
             $this->agentPhilkraService
         );
@@ -203,7 +179,6 @@ class AgentServiceTest extends TestCase
     public function testStartSpanWithNonExistentTransaction(): void
     {
         $agentService = new AgentService(
-            true,
             $this->logger,
             $this->agentPhilkraService
         );
@@ -234,7 +209,6 @@ class AgentServiceTest extends TestCase
         $agentPhilkraService->method('factory')->will($this->returnValue($factoryMock));
 
         $agentService = new AgentService(
-            true,
             $this->logger,
             $agentPhilkraService
         );
@@ -259,7 +233,6 @@ class AgentServiceTest extends TestCase
     public function testStopNonExistentSpan(): void
     {
         $agentService = new AgentService(
-            true,
             $this->logger,
             $this->agentPhilkraService
         );


### PR DESCRIPTION
Toute logique liée à la question "est-ce que elasticApm est activé ou non" a été retirée du wrapper.
Si l'AgentService est instancié, c'est qu'il doit être utilisé.
Cette logique d'activation ou non est déplacée intégralement dans le bundle. Dans celui-ci, si elasticApm est désactivé, AgentService ne doit pas être instancié du tout.
Voir https://github.com/wizaplace/ElasticApmBundle/pull/4/checks